### PR TITLE
Fix macros

### DIFF
--- a/vk_generator/src/generator/defines.rs
+++ b/vk_generator/src/generator/defines.rs
@@ -1,19 +1,19 @@
 #[macro_export]
 macro_rules! vk_make_version {
-    ($major: expr, $minor: expr, $patch: expr) => ((($major as uint32_t) << 22) | (($minor as uint32_t) << 12) | $patch as uint32_t)
+    ($major: expr, $minor: expr, $patch: expr) => ((($major as $crate::uint32_t) << 22) | (($minor as $crate::uint32_t) << 12) | $patch as $crate::uint32_t)
 }
 
 #[macro_export]
 macro_rules! vk_version_major {
-    ($major: expr) => (($major as uint32_t) << 22)
+    ($major: expr) => (($major as $crate::uint32_t) << 22)
 }
 
 #[macro_export]
 macro_rules! vk_version_minor {
-    ($minor: expr) => ((($minor as uint32_t) << 12) & 0x3ff)
+    ($minor: expr) => ((($minor as $crate::uint32_t) << 12) & 0x3ff)
 }
 
 #[macro_export]
 macro_rules! vk_version_patch {
-    ($minor: expr) => (($minor as uint32_t) & 0xfff)
+    ($minor: expr) => (($minor as $crate::uint32_t) & 0xfff)
 }

--- a/vk_generator/src/generator/defines.rs
+++ b/vk_generator/src/generator/defines.rs
@@ -5,12 +5,12 @@ macro_rules! vk_make_version {
 
 #[macro_export]
 macro_rules! vk_version_major {
-    ($major: expr) => (($major as $crate::uint32_t) << 22)
+    ($major: expr) => (($major as $crate::uint32_t) >> 22)
 }
 
 #[macro_export]
 macro_rules! vk_version_minor {
-    ($minor: expr) => ((($minor as $crate::uint32_t) << 12) & 0x3ff)
+    ($minor: expr) => ((($minor as $crate::uint32_t) >> 12) & 0x3ff)
 }
 
 #[macro_export]


### PR DESCRIPTION
Adds `$crate::` to macro-types. Fixes #16 